### PR TITLE
Fix typo in daemon

### DIFF
--- a/surface-dtx-daemon/src/service/arg.rs
+++ b/surface-dtx-daemon/src/service/arg.rs
@@ -98,7 +98,7 @@ impl DbusArg for CancelReason {
                 RuntimeError::Unknown(x)  => format!("error:runtime:unknown:{}", x),
             },
             CancelReason::Hardware(hw) => match hw {
-                HardwareError::FailedToOpen       => "error:hardware:failedt-to-open".into(),
+                HardwareError::FailedToOpen       => "error:hardware:failed-to-open".into(),
                 HardwareError::FailedToRemainOpen => "error:hardware:failed-to-remain-open".into(),
                 HardwareError::FailedToClose      => "error:hardware:failed-to-close".into(),
                 HardwareError::Unknown(x) => format!("error:hardware:unknown:{}", x),


### PR DESCRIPTION
I noticed the user daemon not showing a notification when the latch failed to open. Investigating the logs revealed a typo on the system daemon side:

```
Aug 22 21:01:10 surface systemd[777]: Started Surface Detachment System (DTX) User Daemon.
Aug 22 21:01:10 surface surface-dtx-userd[4581]:   INFO sdtxu: running...
Aug 22 21:01:34 surface surface-dtx-userd[4581]:  ERROR sdtxu: critical error: Protocol error
Aug 22 21:01:34 surface surface-dtx-userd[4581]: Error: Protocol error
Aug 22 21:01:34 surface surface-dtx-userd[4581]: Caused by:
Aug 22 21:01:34 surface surface-dtx-userd[4581]:     0: Protocol error
Aug 22 21:01:34 surface surface-dtx-userd[4581]:     1: Unknown hardware error value: error:hardware:failedt-to-open
Aug 22 21:01:34 surface systemd[777]: surface-dtx-userd.service: Main process exited, code=exited, status=1/FAILURE
Aug 22 21:01:34 surface systemd[777]: surface-dtx-userd.service: Failed with result 'exit-code'.
```

After fixing the misspelled string the user daemon no longer crashes and the notifications work as expected.